### PR TITLE
git: Treat PNGs as binary files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+*.png binary


### PR DESCRIPTION
This avoids auto-conversion. See https://github.com/desktop/desktop/issues/5323