### PR TITLE
front-end: Fix DOM nesting warnings in feed.

### DIFF
--- a/front-end/src/App.css
+++ b/front-end/src/App.css
@@ -1,6 +1,7 @@
 :root {
   color: white;
   background-color: rgb(162, 92, 228);
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
 }
 
 body {

--- a/front-end/src/components/aside/Aside.css
+++ b/front-end/src/components/aside/Aside.css
@@ -1,7 +1,6 @@
 .aside-text {
   padding: 2rem;
   border: 1px solid white;
-  font-family: sans-serif;
   border-radius: 1rem;
   background-color: blueviolet;
   margin: 50px;

--- a/front-end/src/layout/Tabs.jsx
+++ b/front-end/src/layout/Tabs.jsx
@@ -20,7 +20,7 @@ function CustomTabPanel(props) {
     >
       {value === index && (
         <Box sx={{ p: 3 }}>
-          <Typography>{children}</Typography>
+          {children}
         </Box>
       )}
     </div>


### PR DESCRIPTION
Without this, we get warnings like:

```
  Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
  Warning: validateDOMNesting(...): <h2> cannot appear as a descendant of <p>.
```

in the console.

fix it by not wrapping the whole content in a paragraph.

Define the global font to match Material UI.