### PR TITLE
Show generic errors in user update form.

### DIFF
--- a/back-end/controllers/users/updateUserController.js
+++ b/back-end/controllers/users/updateUserController.js
@@ -21,8 +21,6 @@ const updateUserController = async (req, res, next) => {
     // Obtenemos los datos que nos interesan
     const { biography, avatar, username, newPassword } = req.body;
 
-    const fields = []; // Declara el array de campos aquí para que esté disponible en todo el bloque de la función
-
     try {
         // Validamos los datos que envía el usuario.
         await validateSchema(updateUserSchema, req.body);
@@ -63,32 +61,17 @@ const updateUserController = async (req, res, next) => {
             username,
         });
     } catch (err) {
-        // Crear un objeto JSON para los campos afectados en el error.
-        const errorResponse = {
-            error: err.message,
-            fields,
-        };
-
-        const fieldsToCheck = [
+        const fields = [
             'avatar',
             'biography',
             'username',
             'newPassword',
-        ];
+        ].filter(f => err.message.includes(f));
 
-        fieldsToCheck.forEach((field) => {
-            if (err.message.includes(field)) {
-                fields.push(field);
-            }
+	res.status(400).json({
+            message: err.message,
+            fields,
         });
-
-        // Verifica si no hay campos para actualizar
-        if (fields.length === 0) {
-            return res.status(400).json({
-                error: 'No se proporcionaron campos para actualizar',
-            });
-        }
-        res.status(400).json(errorResponse);
     }
 };
 

--- a/front-end/src/components/Forms/UpdateForm.jsx
+++ b/front-end/src/components/Forms/UpdateForm.jsx
@@ -91,20 +91,20 @@ function UpdateForm() {
       const response = await fetch(url, requestOptions);
       const jsonResponse = await response.json();
 
-      if (response.status === 400) {
+      if (response.status === 400 && jsonResponse.fields?.length) {
         // Si la respuesta tiene un estado 400 (Bad Request), maneja los errores
         setErrors({
           username: jsonResponse.fields.includes("username")
-            ? jsonResponse.error
+            ? jsonResponse.message
             : "",
           biography: jsonResponse.fields.includes("biography")
-            ? jsonResponse.error
+            ? jsonResponse.message
             : "",
           avatar: jsonResponse.fields.includes("avatar")
-            ? jsonResponse.error
+            ? jsonResponse.message
             : "",
           newPassword: jsonResponse.fields.includes("newPassword")
-            ? jsonResponse.error
+            ? jsonResponse.message
             : "",
         });
       } else if (!response.ok) {
@@ -123,7 +123,9 @@ function UpdateForm() {
         });
       }
     } catch (error) {
-      console.error("Error updating profile:", error);
+      toast.error(error.message, {
+        position: toast.POSITION.TOP_CENTER
+      })
     }
   };
 


### PR DESCRIPTION
If you update with an existing (different) user name, for example, there would be no error displayed to the user without this change.